### PR TITLE
Add spacing between blog post title and metadata

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2479,6 +2479,10 @@
   color: #161b25;
 }
 
+.obsidian-post-header .obsidian-entry-header {
+  margin-top: 0.85rem;
+}
+
 .obsidian-post-description {
   width: min(100%, 42rem);
   margin: 1rem 0 0;


### PR DESCRIPTION
### Motivation
- The date/views row on blog post detail pages sits too close to the title, so add a small vertical gap scoped to post pages to improve readability.

### Description
- Add a scoped CSS rule in `src/app/globals.css` (`.obsidian-post-header .obsidian-entry-header { margin-top: 0.85rem; }`) so the metadata row gets extra top spacing only when rendered under `.obsidian-post-header`.

### Testing
- Started the dev server with `pnpm dev` and captured a Playwright screenshot of `/blog/first-post` to visually verify the spacing (screenshot artifact produced); `pnpm exec eslint src/app/globals.css` and `pnpm lint` were attempted but failed due to existing lint/config issues in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b783830db08327921445ef47f2d664)